### PR TITLE
Migrate to wp-env

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,3 +15,4 @@ jobs:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
         SLUG: activitystream-extension
+        README_NAME: README.md

--- a/.github/workflows/update-assets.yml
+++ b/.github/workflows/update-assets.yml
@@ -15,3 +15,4 @@ jobs:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
         SLUG: activitystream-extension
+        README_NAME: README.md


### PR DESCRIPTION
## Summary
- Remove Grunt build configuration
- Add wp-env for local development
- Remove readme.txt in favor of README.md
- Update workflows to use README.md

## Test plan
- [ ] Run `npm install && npm run env:start`
- [ ] Verify plugin activates correctly in WordPress