### PR TITLE
Rename pubsubhubbub_ filter to websub_ and release 1.3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 - Donate link: https://notiz.blog/donate/
 - Tags: ActivityStreams, feed, RSS, Atom, JSON-LD
 - Requires at least: 4.2
-- Tested up to: 6.5
-- Stable tag: 1.3.8
+- Tested up to: 7.0
+- Stable tag: 1.3.9
 
 ActivityStrea.ms feeds for WordPress (Atom and JSON(-LD))
 
@@ -25,6 +25,10 @@ Thats it
 ## Changelog
 
 Project maintined on github at [pfefferle/wordpress-activitystream-extension](https://github.com/pfefferle/wordpress-activitystream-extension/).
+
+### 1.3.9
+
+* renamed `pubsubhubbub_supported_feed_types` filter to `websub_supported_feed_types`
 
 ### 1.3.8
 

--- a/activitystream-extension.php
+++ b/activitystream-extension.php
@@ -5,7 +5,7 @@
  * Description: An extensions which adds several ActivityStreams (<a href="http://www.activitystrea.ms">activitystrea.ms</a>) Feeds
  * Author: Matthias Pfefferle
  * Author URI: https://notiz.blog
- * Version: 1.3.8
+ * Version: 1.3.9
  * License: MIT
  * License URI: https://opensource.org/licenses/MIT
  * Text Domain: activitystream-extension
@@ -43,7 +43,7 @@ class ActivityStreamExtensionPlugin {
 		add_filter( 'as2_object_type', array( 'ActivityStreamExtensionPlugin', 'post_as2_object_type' ), 10, 2 );
 
 		// push json feed
-		add_filter( 'pubsubhubbub_supported_feed_types', array( 'ActivityStreamExtensionPlugin', 'supported_feed_types' ) );
+		add_filter( 'websub_supported_feed_types', array( 'ActivityStreamExtensionPlugin', 'supported_feed_types' ) );
 
 		// extend core feeds with AS1
 		add_action( 'atom_ns', array( 'ActivityStreamExtensionPlugin', 'add_atom_activity_namespace' ) );


### PR DESCRIPTION
## Summary

- Renames the `pubsubhubbub_supported_feed_types` filter to `websub_supported_feed_types` to match the renamed WebSub plugin.
- Bumps the version to **1.3.9** (plugin header + `README.md` stable tag + changelog).
- Updates **Tested up to** to WordPress **7.0**.

## ⚠️ Backwards compatibility

The plugin now only hooks `websub_supported_feed_types`. On older WebSub/PubSubHubbub installs that still fire `pubsubhubbub_supported_feed_types`, the `as1`/`as2` feeds will no longer be registered for push. If supporting both is desired, the filter can be added on both hook names.

## Test plan

- [ ] Confirm `as1`/`as2` feeds are registered for WebSub push with a current WebSub plugin version.